### PR TITLE
Add plugin store and calc browser plugin

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,10 @@
+
+from flask import Flask
+app = Flask(__name__)
+
+@app.route("/")
+def home():
+    return "IVP backend is running."
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,4 @@
+
+#!/bin/bash
+echo "Deploying IVP stack..."
+# Add your domain/SSL/server logic here

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,18 @@
+
+# IVP Starter Bundle
+
+This is the starter pack for IVP (Internet Visionary Provider). It includes:
+
+- Frontend: `index.html`
+- Backend: Flask app
+- Q&A Plugin: `whisper_bot.js`
+- Deploy scaffold
+- Certs placeholder
+
+## Plugin Store
+
+A simple plugin store is available at `frontend/plug_store.html`. It loads the sample `whisper_bot.js` and a new `calc_browser_plugin.js` which opens the Calc Lang Scroll Forge page in a new window.
+
+## Calc Lang Scroll Forge
+
+The `calc_lang.html` file is a placeholder representing the Calc Lang Scroll Forge environment that opens when using the plugin.

--- a/frontend/calc_lang.html
+++ b/frontend/calc_lang.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Calc Lang Scroll Forge</title>
+</head>
+<body>
+  <h1>Calc Lang Scroll Forge</h1>
+  <p>This is a placeholder page representing the Calc Lang Scroll Forge environment.</p>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+  <title>IVP Launch Page</title>
+</head>
+<body>
+  <h1>Welcome to IVP</h1>
+  <p>Your full-stack Q&A-powered site is ready.</p>
+</body>
+</html>

--- a/frontend/plug_store.html
+++ b/frontend/plug_store.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>IVP Plugin Store</title>
+  <script src="../qna_plugin/whisper_bot.js"></script>
+  <script src="../qna_plugin/calc_browser_plugin.js"></script>
+</head>
+<body>
+  <h1>Plugin Store</h1>
+  <button onclick="alert(askIVP('How are you?'))">Use Whisper Bot</button>
+  <button onclick="openCalcLangForge()">Open Calc Lang Scroll Forge</button>
+</body>
+</html>

--- a/qna_plugin/calc_browser_plugin.js
+++ b/qna_plugin/calc_browser_plugin.js
@@ -1,0 +1,4 @@
+// Plugin to open Calc Lang Scroll Forge in a new window
+function openCalcLangForge() {
+  window.open('../frontend/calc_lang.html', '_blank');
+}

--- a/qna_plugin/whisper_bot.js
+++ b/qna_plugin/whisper_bot.js
@@ -1,0 +1,5 @@
+
+// Simple Q&A Whisper Bot plugin
+function askIVP(question) {
+  return "Answering: " + question + " (powered by IVP WhisperBot)";
+}


### PR DESCRIPTION
## Summary
- add a simple plugin store HTML page
- add a plugin to open the Calc Lang Scroll Forge page
- document plugin store and Calc Lang page in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686443e3ba948325bab818477bb9a0be