### PR TITLE
Add IVP project API and launch UI

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,103 @@
+
+from datetime import datetime, timezone
+from pathlib import Path
+from flask import Flask, jsonify, request, send_from_directory
+
+app = Flask(__name__)
+frontend_dir = Path(__file__).resolve().parents[1] / "frontend"
+
+projects = []
+next_project_id = 1
+
+
+def seed_projects():
+    global next_project_id
+    projects.append(
+        {
+            "id": next_project_id,
+            "name": "Launchpad",
+            "description": "Template project with a ready-to-use API surface.",
+            "status": "active",
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "api_key": "ivp_demo_key_123",
+        }
+    )
+    next_project_id += 1
+
+
+seed_projects()
+
+@app.route("/")
+def home():
+    return "IVP backend is running."
+
+
+@app.get("/app")
+def launch_app():
+    return send_from_directory(frontend_dir, "index.html")
+
+
+@app.get("/api/projects")
+def list_projects():
+    return jsonify({"projects": projects})
+
+
+@app.post("/api/projects")
+def create_project():
+    global next_project_id
+    payload = request.get_json(silent=True) or {}
+    name = payload.get("name", "").strip()
+    description = payload.get("description", "").strip()
+    if not name:
+        return jsonify({"error": "Project name is required."}), 400
+    project = {
+        "id": next_project_id,
+        "name": name,
+        "description": description or "No description provided yet.",
+        "status": "active",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "api_key": f"ivp_{next_project_id:04d}_key",
+    }
+    projects.append(project)
+    next_project_id += 1
+    return jsonify(project), 201
+
+
+@app.get("/api/projects/<int:project_id>")
+def get_project(project_id):
+    project = next((item for item in projects if item["id"] == project_id), None)
+    if project is None:
+        return jsonify({"error": "Project not found."}), 404
+    return jsonify(project)
+
+
+@app.get("/api/quickstart")
+def quickstart():
+    return jsonify(
+        {
+            "title": "Streamline new projects with the IVP API",
+            "steps": [
+                "POST /api/projects to create a new project.",
+                "Store the api_key from the response.",
+                "GET /api/projects to list all projects.",
+                "GET /api/projects/<id> to fetch a specific project.",
+            ],
+            "examples": {
+                "create_project": {
+                    "method": "POST",
+                    "url": "/api/projects",
+                    "body": {
+                        "name": "Customer Success Hub",
+                        "description": "Unified workspace for onboarding, support, and analytics.",
+                    },
+                },
+                "list_projects": {
+                    "method": "GET",
+                    "url": "/api/projects",
+                },
+            },
+        }
+    )
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,4 @@
+
+#!/bin/bash
+echo "Deploying IVP stack..."
+# Add your domain/SSL/server logic here

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+
+# IVP Starter Bundle
+
+This is the starter pack for IVP (Internet Visionary Provider). It includes:
+
+- Frontend: `index.html`
+- Backend: Flask app
+- Q&A Plugin: `whisper_bot.js`
+- Deploy scaffold
+- Certs placeholder

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,159 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+  <title>IVP Launch Page</title>
+  <style>
+    body {
+      font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+      margin: 0;
+      background: #f5f7fb;
+      color: #1d2433;
+    }
+    header {
+      background: #111827;
+      color: #f9fafb;
+      padding: 48px 24px 32px;
+    }
+    header h1 {
+      margin: 0 0 12px;
+      font-size: 2.4rem;
+    }
+    header p {
+      margin: 0;
+      max-width: 640px;
+      line-height: 1.6;
+    }
+    main {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 32px 24px 56px;
+      display: grid;
+      gap: 24px;
+    }
+    section {
+      background: #ffffff;
+      border-radius: 16px;
+      padding: 24px;
+      box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+    }
+    h2 {
+      margin-top: 0;
+      color: #111827;
+    }
+    ul {
+      padding-left: 20px;
+    }
+    .project-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 16px;
+    }
+    .project-card {
+      border: 1px solid #e5e7eb;
+      border-radius: 12px;
+      padding: 16px;
+      background: #f9fafb;
+    }
+    code {
+      display: block;
+      background: #0f172a;
+      color: #e2e8f0;
+      padding: 12px;
+      border-radius: 10px;
+      font-size: 0.9rem;
+      white-space: pre-wrap;
+    }
+    .muted {
+      color: #6b7280;
+      font-size: 0.95rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>IVP Project Launch Studio</h1>
+    <p>
+      Streamline every new project with a ready-to-use API. Create, list, and
+      manage initiatives in seconds, then plug the API key into your workflows.
+    </p>
+  </header>
+  <main>
+    <section>
+      <h2>Quickstart with the IVP API</h2>
+      <p class="muted" id="quickstart-title">Loading API guide...</p>
+      <ul id="quickstart-steps"></ul>
+      <code id="quickstart-example"></code>
+    </section>
+
+    <section>
+      <h2>Active Projects</h2>
+      <p class="muted">Created through the API and ready for collaboration.</p>
+      <div class="project-grid" id="project-grid"></div>
+    </section>
+
+    <section>
+      <h2>How to Use the API</h2>
+      <p>
+        Send a JSON payload to <strong>/api/projects</strong> to spin up a new
+        workspace instantly.
+      </p>
+      <code>
+curl -X POST http://localhost:5000/api/projects \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Growth Metrics", "description": "Unified analytics and KPI tracking."}'
+      </code>
+    </section>
+  </main>
+  <script>
+    const quickstartTitle = document.getElementById("quickstart-title");
+    const quickstartSteps = document.getElementById("quickstart-steps");
+    const quickstartExample = document.getElementById("quickstart-example");
+    const projectGrid = document.getElementById("project-grid");
+
+    function renderProjects(projects) {
+      projectGrid.innerHTML = "";
+      projects.forEach((project) => {
+        const card = document.createElement("div");
+        card.className = "project-card";
+        card.innerHTML = `
+          <h3>${project.name}</h3>
+          <p class="muted">${project.description}</p>
+          <p><strong>Status:</strong> ${project.status}</p>
+          <p><strong>API Key:</strong> ${project.api_key}</p>
+          <p class="muted">Created ${new Date(project.created_at).toLocaleString()}</p>
+        `;
+        projectGrid.appendChild(card);
+      });
+    }
+
+    async function loadData() {
+      try {
+        const [quickstartResponse, projectsResponse] = await Promise.all([
+          fetch("/api/quickstart"),
+          fetch("/api/projects"),
+        ]);
+        const quickstart = await quickstartResponse.json();
+        const projects = await projectsResponse.json();
+
+        quickstartTitle.textContent = quickstart.title;
+        quickstartSteps.innerHTML = quickstart.steps
+          .map((step) => `<li>${step}</li>`)
+          .join("");
+        quickstartExample.textContent = `${quickstart.examples.create_project.method} ${quickstart.examples.create_project.url}\n\n${JSON.stringify(
+          quickstart.examples.create_project.body,
+          null,
+          2
+        )}`;
+
+        renderProjects(projects.projects);
+      } catch (error) {
+        quickstartTitle.textContent = "Unable to load API guide.";
+        quickstartExample.textContent = "Start the backend to fetch API data.";
+      }
+    }
+
+    loadData();
+  </script>
+</body>
+</html>

--- a/qna_plugin/whisper_bot.js
+++ b/qna_plugin/whisper_bot.js
@@ -1,0 +1,5 @@
+
+// Simple Q&A Whisper Bot plugin
+function askIVP(question) {
+  return "Answering: " + question + " (powered by IVP WhisperBot)";
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal HTTP API to streamline creating and managing new projects programmatically.
- Ship a small, opinionated frontend that demonstrates how to use the API and visualizes active projects.
- Include a compact starter bundle (docs, deploy scaffold, Q&A plugin) so the project is runnable as a demo.

### Description
- Add an in-memory Flask API with endpoints `GET /api/projects`, `POST /api/projects`, `GET /api/projects/<id>`, and `GET /api/quickstart` that return JSON demo data and quickstart guidance.
- Add a `/app` route that serves the frontend `index.html` from the backend and a seeded demo project in `backend/app.py`.
- Implement a refreshed launch page in `frontend/index.html` that fetches `/api/quickstart` and `/api/projects`, renders quickstart steps and project cards, and includes a `curl` usage example.
- Add supporting starter files: `docs/README.md`, `deploy/deploy.sh`, and a simple `qna_plugin/whisper_bot.js` example.

### Testing
- Attempted to run the backend with `python backend/app.py`, which failed due to missing dependency `flask` (automated run produced `ModuleNotFoundError`).
- Started a static server for the frontend with `python -m http.server 8000` in `frontend`, which began serving successfully.
- Attempted an automated Playwright screenshot of the frontend, but Chromium crashed in this environment (SIGSEGV), so end-to-end rendering verification did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695061135b1083258bb32e0109289ab3)