### PR TITLE
Add Lucera narrative template and IVP starter bundle

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,10 @@
+
+from flask import Flask
+app = Flask(__name__)
+
+@app.route("/")
+def home():
+    return "IVP backend is running."
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,4 @@
+
+#!/bin/bash
+echo "Deploying IVP stack..."
+# Add your domain/SSL/server logic here

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+
+# IVP Starter Bundle
+
+This is the starter pack for IVP (Internet Visionary Provider). It includes:
+
+- Frontend: `index.html`
+- Backend: Flask app
+- Q&A Plugin: `whisper_bot.js`
+- Deploy scaffold
+- Certs placeholder

--- a/docs/lucera_narrative.md
+++ b/docs/lucera_narrative.md
@@ -1,0 +1,101 @@
+# Lucera Narrative Template
+
+## Template
+
+**Title:**
+
+**Logline (1–2 sentences):**
+
+**Theme (what the story proves):**
+
+**Setting (time/place/atmosphere):**
+
+**Core Promise (what makes Lucera unique):**
+
+**Main Characters:**
+- **Protagonist:**
+  - Goal:
+  - Need (internal growth):
+  - Wound (what shaped them):
+- **Antagonist/Force of Opposition:**
+  - Goal:
+  - Pressure it applies:
+- **Key Allies:**
+
+**Inciting Incident (what upends normal life):**
+
+**Act I — Setup (opening image → commitment):**
+
+**Act II — Confrontation (tests → revelation):**
+- **Rising Challenges:**
+- **Midpoint Reversal (stakes shift):**
+- **All Is Lost (lowest moment):**
+
+**Act III — Resolution (choice → climax):**
+- **Final Choice (theme in action):**
+- **Climax:**
+- **New Equilibrium:**
+
+**Signature Lucera Moments (visuals/symbols/motifs):**
+
+**Closing Image (mirrors the opening):**
+
+---
+
+## Story-Driven Example (Lucera)
+
+**Title:** *Lucera: The Lantern City*
+
+**Logline (1–2 sentences):**
+In a city that survives on harvested starlight, a cautious apprentice lamplighter must choose between preserving tradition and risking everything to save the light itself.
+
+**Theme (what the story proves):**
+Light grows when it’s shared, even if it costs the keeper.
+
+**Setting (time/place/atmosphere):**
+Lucera, a cliffside city of glass bridges and wind-hung lanterns, glows above a midnight sea; below, the world is dim and forgotten.
+
+**Core Promise (what makes Lucera unique):**
+Every lantern holds a fragment of memory-starlight. Losing light means losing who the city is.
+
+**Main Characters:**
+- **Protagonist:** Nila, an apprentice lamplighter
+  - Goal: Keep the lantern lines lit and earn her mantle.
+  - Need (internal growth): Learn that protecting light requires sharing it.
+  - Wound (what shaped them): Her mentor vanished on a forbidden light-harvest.
+- **Antagonist/Force of Opposition:** The Dimming, a creeping void fed by hoarded light
+  - Goal: Consume isolated lanterns and scatter memory.
+  - Pressure it applies: Fear of change, fear of losing the city’s past.
+- **Key Allies:**
+  - Orin, a wind-sail pilot who knows the lower ruins.
+  - Yara, a memory-weaver who can read lantern light.
+
+**Inciting Incident (what upends normal life):**
+A chain of lanterns goes dark in a single night, and Nila finds her mentor’s seal etched into the glass—proof they might still live.
+
+**Act I — Setup (opening image → commitment):**
+Nila lights the morning bridge and vows to keep the routes safe. The council forbids travel beyond the city rim, but Nila accepts Orin’s offer to search the lower ruins after finding the seal.
+
+**Act II — Confrontation (tests → revelation):**
+- **Rising Challenges:**
+  - The wind lines snap, scattering light; the council blames Nila.
+  - The ruins reveal abandoned lantern vaults, drained of memory.
+  - Yara deciphers a warning in the seal: “Light kept alone will fail.”
+- **Midpoint Reversal (stakes shift):**
+Nila discovers her mentor intentionally released light to save the lower world, proving the city’s survival depends on sharing.
+- **All Is Lost (lowest moment):**
+The Dimming swallows the central spire, and the council moves to lock away the remaining lanterns—dooming the lower world and Lucera’s future.
+
+**Act III — Resolution (choice → climax):**
+- **Final Choice (theme in action):**
+Nila opens the great lantern vault, risking the city’s identity to spread light outward.
+- **Climax:**
+The released starlight ignites the wind bridges, driving back the Dimming while rekindling the lower ruins.
+- **New Equilibrium:**
+Lucera becomes a beacon, its lanterns now fueled by shared light and restored memory.
+
+**Signature Lucera Moments (visuals/symbols/motifs):**
+Wind-sung bridges, floating glass lanterns, memory-starlight blooming like auroras.
+
+**Closing Image (mirrors the opening):**
+Nila lights a lantern not for the city alone, but for the horizon below.

--- a/docs/lucera_narrative.md
+++ b/docs/lucera_narrative.md
@@ -104,13 +104,13 @@ Nila lights a lantern not for the city alone, but for the horizon below.
 
 ## First Sequence of Events (Lucera)
 
-1. **Opening Image:** Dawn spreads over Lucera’s glass bridges as lanterns flicker in the morning wind.
-2. **Daily Rite:** Nila completes the morning lighting run, reciting the lamplighter’s vows.
-3. **Small Glitch:** One lantern sputters with a faint echo of someone else’s memory-starlight.
-4. **Warning Whisper:** Yara, the memory-weaver, notes the light is “fraying” in an unusual pattern.
-5. **Public Disruption:** A chain of lanterns on the east span goes dark, causing a brief bridge closure.
-6. **Council Edict:** The council orders all lamplighters to keep routes close to the city rim.
-7. **Inciting Clue:** Nila finds her mentor’s seal etched into the darkened glass.
-8. **Private Choice:** She hides the seal from the council, keeping it as proof.
-9. **Ally Offer:** Orin offers a wind-sail to the lower ruins, claiming to have seen strange lights below.
-10. **Commitment:** Nila agrees to meet Orin at dusk, stepping toward the forbidden edge.
+1. Dawn spreads over Lucera’s glass bridges as lanterns flicker in the morning wind.
+2. Nila completes the morning lighting run, reciting the lamplighter’s vows.
+3. One lantern sputters with a faint echo of someone else’s memory-starlight.
+4. Yara, the memory-weaver, notes the light is “fraying” in an unusual pattern.
+5. A chain of lanterns on the east span goes dark, causing a brief bridge closure.
+6. The council orders all lamplighters to keep routes close to the city rim.
+7. Nila finds her mentor’s seal etched into the darkened glass.
+8. She hides the seal from the council, keeping it as proof.
+9. Orin offers a wind-sail to the lower ruins, claiming to have seen strange lights below.
+10. Nila agrees to meet Orin at dusk, stepping toward the forbidden edge.

--- a/docs/lucera_narrative.md
+++ b/docs/lucera_narrative.md
@@ -99,3 +99,18 @@ Wind-sung bridges, floating glass lanterns, memory-starlight blooming like auror
 
 **Closing Image (mirrors the opening):**
 Nila lights a lantern not for the city alone, but for the horizon below.
+
+---
+
+## First Sequence of Events (Lucera)
+
+1. **Opening Image:** Dawn spreads over Lucera’s glass bridges as lanterns flicker in the morning wind.
+2. **Daily Rite:** Nila completes the morning lighting run, reciting the lamplighter’s vows.
+3. **Small Glitch:** One lantern sputters with a faint echo of someone else’s memory-starlight.
+4. **Warning Whisper:** Yara, the memory-weaver, notes the light is “fraying” in an unusual pattern.
+5. **Public Disruption:** A chain of lanterns on the east span goes dark, causing a brief bridge closure.
+6. **Council Edict:** The council orders all lamplighters to keep routes close to the city rim.
+7. **Inciting Clue:** Nila finds her mentor’s seal etched into the darkened glass.
+8. **Private Choice:** She hides the seal from the council, keeping it as proof.
+9. **Ally Offer:** Orin offers a wind-sail to the lower ruins, claiming to have seen strange lights below.
+10. **Commitment:** Nila agrees to meet Orin at dusk, stepping toward the forbidden edge.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+  <title>IVP Launch Page</title>
+</head>
+<body>
+  <h1>Welcome to IVP</h1>
+  <p>Your full-stack Q&A-powered site is ready.</p>
+</body>
+</html>

--- a/qna_plugin/whisper_bot.js
+++ b/qna_plugin/whisper_bot.js
@@ -1,0 +1,5 @@
+
+// Simple Q&A Whisper Bot plugin
+function askIVP(question) {
+  return "Answering: " + question + " (powered by IVP WhisperBot)";
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal IVP starter bundle (frontend, backend, Q&A plugin, deploy scaffold, and certs placeholder) to jumpstart development.
- Capture a reusable story template for the Lucera setting to guide narrative-driven content creation.

### Description
- Add a Lucera narrative template and a story-driven example in `docs/lucera_narrative.md` to standardize story structure.
- Add a docs index `docs/README.md` describing the starter bundle contents.
- Add a minimal Flask backend at `backend/app.py` with a `home` route returning a health string.
- Add `frontend/index.html`, `qna_plugin/whisper_bot.js`, and a simple deploy script `deploy/deploy.sh` as starter artifacts.

### Testing
- No automated tests were run for this change.
- Repository state was verified via `git status` and file creation was confirmed by listing the new files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950a6777f0c83259a3e5f74bc9cc561)