### PR TITLE
Add VeloraChat starter UI, docs, packaging scripts, and backend stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+dist/

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,10 @@
+
+from flask import Flask
+app = Flask(__name__)
+
+@app.route("/")
+def home():
+    return "IVP backend is running."
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/deploy/build_owner_pack.sh
+++ b/deploy/build_owner_pack.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PACK_DIR="${ROOT_DIR}/pack/velorachat-owner-pack"
+DIST_DIR="${ROOT_DIR}/dist"
+ZIP_FILE="${DIST_DIR}/velorachat-owner-pack.zip"
+
+mkdir -p "${PACK_DIR}/brand" "${PACK_DIR}/app-store" "${DIST_DIR}"
+
+cp "${ROOT_DIR}/docs/BRAND_KIT.md" "${PACK_DIR}/brand/BRAND_KIT.md"
+cp "${ROOT_DIR}/docs/APP_STORE_SUBMISSION_CHECKLIST.md" "${PACK_DIR}/app-store/APP_STORE_SUBMISSION_CHECKLIST.md"
+cp "${ROOT_DIR}/frontend/index.html" "${PACK_DIR}/product-preview.html"
+
+cd "${ROOT_DIR}/pack"
+zip -r "${ZIP_FILE}" "velorachat-owner-pack" >/dev/null
+
+echo "Owner pack refreshed at: ${PACK_DIR}"
+echo "Owner pack zip created: ${ZIP_FILE}"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Deploying VeloraChat starter stack..."
+echo "Tip: create the business ZIP pack with: bash deploy/package_business_files.sh"
+# Add your domain/SSL/server logic here.

--- a/deploy/package_business_files.sh
+++ b/deploy/package_business_files.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST_DIR="${ROOT_DIR}/dist"
+OUT_FILE="${DIST_DIR}/velorachat-business-pack.zip"
+
+mkdir -p "${DIST_DIR}"
+
+cd "${ROOT_DIR}"
+
+zip -r "${OUT_FILE}" \
+  docs/README.md \
+  docs/BUSINESS_PACK.md \
+  docs/APP_STORE_SUBMISSION_CHECKLIST.md \
+  docs/BRAND_KIT.md \
+  frontend/index.html \
+  backend/app.py \
+  deploy/deploy.sh \
+  qna_plugin/whisper_bot.js >/dev/null
+
+echo "Business pack created: ${OUT_FILE}"

--- a/docs/APP_STORE_SUBMISSION_CHECKLIST.md
+++ b/docs/APP_STORE_SUBMISSION_CHECKLIST.md
@@ -1,0 +1,33 @@
+# App Store Submission Checklist (iPhone)
+
+Use this checklist before submitting VeloraChat to Apple.
+
+## 1) App information
+- [ ] Final app name confirmed: **VeloraChat**
+- [ ] Subtitle finalized
+- [ ] Category selected (e.g., Social Networking)
+- [ ] Age rating questionnaire completed
+
+## 2) Legal and policy
+- [ ] Privacy Policy URL ready
+- [ ] Terms of Use URL ready
+- [ ] Data collection details mapped for App Privacy labels
+- [ ] Encryption/export compliance reviewed
+
+## 3) Assets and metadata
+- [ ] App icon exported in required sizes
+- [ ] iPhone screenshots captured for required screen sizes
+- [ ] Promotional text and description finalized
+- [ ] Keywords and support URL completed
+
+## 4) Technical readiness
+- [ ] Production API environment configured
+- [ ] Sign in with Apple tested (if account system exists)
+- [ ] Push notifications (APNs) validated
+- [ ] Crash and analytics monitoring enabled
+
+## 5) Review readiness
+- [ ] Test account credentials prepared for reviewer
+- [ ] Demo steps documented for app review team
+- [ ] Content moderation/reporting flow available
+- [ ] Build uploaded and processed in App Store Connect

--- a/docs/BRAND_KIT.md
+++ b/docs/BRAND_KIT.md
@@ -1,0 +1,30 @@
+# VeloraChat Brand Kit
+
+## Core identity
+- **Brand name:** VeloraChat
+- **Style name:** Lunar Glass
+- **Brand promise:** A premium private messaging experience with calm visual flow.
+
+## Voice and tone
+- Warm, modern, and reassuring.
+- Clear wording over technical jargon.
+- Privacy-forward language in user-facing copy.
+
+## Color system
+- Background: `#0b1020`
+- Surface card: `#141a30`
+- Accent aqua: `#73f0d1`
+- Accent indigo: `#5a7dff`
+- Primary text: `#eff3ff`
+- Secondary text: `#9ba8c7`
+
+## Emblem guidance
+- Primary shape: rounded chat bubble.
+- Signature detail: three message dots.
+- Optional ring/glow: gradient orbit for premium feel.
+- Must be readable at small icon sizes.
+
+## Tagline options
+1. Private moments, elegant flow.
+2. Message clearly. Connect calmly.
+3. Your conversations, beautifully secure.

--- a/docs/BUSINESS_PACK.md
+++ b/docs/BUSINESS_PACK.md
@@ -1,0 +1,34 @@
+# VeloraChat Business Pack
+
+This document is your single source of truth for packaging the business materials for your app.
+
+## Product identity
+- **App name:** VeloraChat
+- **Style system:** Lunar Glass
+- **Tagline:** Private moments, elegant flow.
+- **Emblem concept:** Chat bubble with 3 message dots and a glow orbit.
+
+## Business files included in the pack
+- `docs/BRAND_KIT.md` — brand voice, colors, and emblem guidance.
+- `docs/APP_STORE_SUBMISSION_CHECKLIST.md` — practical submission checklist.
+- `docs/README.md` — quick-start and packaging instructions.
+- `frontend/index.html` — visual concept screen and iPhone-style preview.
+
+## How to generate the ZIP package
+
+```bash
+bash deploy/package_business_files.sh
+```
+
+Output archive:
+
+- `dist/velorachat-business-pack.zip`
+
+## Recommended owner workflow
+1. Keep brand decisions in `docs/BRAND_KIT.md`.
+2. Track release readiness in `docs/APP_STORE_SUBMISSION_CHECKLIST.md`.
+3. Regenerate the ZIP whenever files are updated.
+
+
+## Owner pack output
+Use `bash deploy/build_owner_pack.sh` to keep an always-updated folder at `pack/velorachat-owner-pack/` plus a ZIP in `dist/`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,50 @@
+# VeloraChat Business + App Starter
+
+This repository now includes a **business pack** and a **technical starter** so you can keep everything in your files and move toward iPhone App Store release.
+
+## What is included
+
+- Product concept screen: `frontend/index.html`
+- Backend starter: `backend/app.py`
+- Plugin scaffold: `qna_plugin/whisper_bot.js`
+- Deployment helper: `deploy/deploy.sh`
+- Business pack guide: `docs/BUSINESS_PACK.md`
+- App Store checklist: `docs/APP_STORE_SUBMISSION_CHECKLIST.md`
+- Brand kit: `docs/BRAND_KIT.md`
+
+## Create the business pack ZIP in your files
+
+Run:
+
+```bash
+bash deploy/package_business_files.sh
+```
+
+This generates:
+
+- `dist/velorachat-business-pack.zip`
+
+## Suggested next build steps
+
+1. Implement messaging APIs + persistence.
+2. Add Sign in with Apple and onboarding.
+3. Add APNs push notifications.
+4. Create native iOS project and integrate backend.
+5. Complete App Store Connect metadata and privacy details.
+
+
+## Owner-friendly pack (folder + ZIP)
+
+Run:
+
+```bash
+bash deploy/build_owner_pack.sh
+```
+
+This refreshes a readable folder in your files:
+
+- `pack/velorachat-owner-pack/`
+
+And creates a shareable ZIP:
+
+- `dist/velorachat-owner-pack.zip`

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="theme-color" content="#10131f" />
+  <title>VeloraChat — Private Messaging</title>
+  <style>
+    :root {
+      --bg: #0b1020;
+      --card: #141a30;
+      --muted: #9ba8c7;
+      --text: #eff3ff;
+      --brand: #73f0d1;
+      --brand-2: #5a7dff;
+      --bubble-self: #273a7a;
+      --bubble-other: #1d294d;
+      --border: rgba(255, 255, 255, 0.12);
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto, sans-serif;
+      background: radial-gradient(circle at top right, #152047 0%, var(--bg) 55%);
+      color: var(--text);
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: 24px;
+    }
+
+    .app-shell {
+      width: min(980px, 100%);
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 24px;
+    }
+
+    .panel {
+      background: linear-gradient(160deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0));
+      border: 1px solid var(--border);
+      border-radius: 24px;
+      padding: 22px;
+      backdrop-filter: blur(8px);
+      box-shadow: 0 10px 40px rgba(0, 0, 0, 0.35);
+    }
+
+    h1, h2, h3, p {
+      margin-top: 0;
+    }
+
+    .brand-row {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      margin-bottom: 18px;
+    }
+
+    .brand-chip {
+      font-size: 12px;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--brand);
+      border: 1px solid rgba(115, 240, 209, 0.35);
+      border-radius: 999px;
+      padding: 6px 10px;
+    }
+
+    .muted {
+      color: var(--muted);
+      line-height: 1.55;
+    }
+
+    .phone {
+      width: 290px;
+      max-width: 100%;
+      margin: 20px auto 0;
+      border-radius: 36px;
+      border: 10px solid #0a0d16;
+      background: #111833;
+      overflow: hidden;
+      box-shadow: 0 18px 60px rgba(0, 0, 0, 0.5);
+    }
+
+    .phone-notch {
+      width: 42%;
+      height: 24px;
+      border-radius: 0 0 14px 14px;
+      background: #0a0d16;
+      margin: 0 auto;
+    }
+
+    .splash {
+      min-height: 210px;
+      display: grid;
+      place-items: center;
+      background: linear-gradient(160deg, #1e2960 0%, #18224f 45%, #0f1430 100%);
+      padding: 18px;
+      text-align: center;
+    }
+
+    .splash h3 {
+      margin: 12px 0 4px;
+      font-size: 22px;
+    }
+
+    .splash p {
+      margin: 0;
+      color: #b9c8ee;
+      font-size: 13px;
+    }
+
+    .chat {
+      padding: 14px;
+      border-top: 1px solid var(--border);
+      display: grid;
+      gap: 10px;
+      background: #101736;
+    }
+
+    .msg {
+      max-width: 78%;
+      padding: 10px 12px;
+      border-radius: 14px;
+      font-size: 14px;
+      line-height: 1.35;
+    }
+
+    .other { background: var(--bubble-other); }
+    .self {
+      background: var(--bubble-self);
+      margin-left: auto;
+    }
+
+    .appstore-list {
+      padding-left: 18px;
+      line-height: 1.7;
+      color: #d4dcf5;
+    }
+
+    .appstore-list li::marker { color: var(--brand); }
+
+    @media (max-width: 860px) {
+      .app-shell { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <main class="app-shell">
+    <section class="panel">
+      <div class="brand-row">
+        <svg width="56" height="56" viewBox="0 0 100 100" role="img" aria-label="VeloraChat emblem">
+          <defs>
+            <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stop-color="#73f0d1" />
+              <stop offset="100%" stop-color="#5a7dff" />
+            </linearGradient>
+          </defs>
+          <circle cx="50" cy="50" r="42" fill="url(#g)" opacity="0.18" />
+          <path d="M26 50c0-13 11-24 24-24h24v20c0 13-11 24-24 24h-9l-12 10 3-14c-4-4-6-10-6-16z" fill="none" stroke="url(#g)" stroke-width="6" stroke-linejoin="round" />
+          <circle cx="46" cy="50" r="3" fill="#73f0d1" />
+          <circle cx="58" cy="50" r="3" fill="#73f0d1" />
+          <circle cx="70" cy="50" r="3" fill="#73f0d1" />
+        </svg>
+        <div>
+          <h1>VeloraChat</h1>
+          <div class="brand-chip">Signature Style: Lunar Glass</div>
+        </div>
+      </div>
+      <p class="muted">
+        A uniquely branded messaging app concept with an iPhone-first visual language.
+        Emblem + name are ready for splash screens, App Store marketing art, and icon exploration.
+      </p>
+
+      <article class="phone" aria-label="iPhone preview">
+        <div class="phone-notch"></div>
+        <div class="splash">
+          <svg width="62" height="62" viewBox="0 0 100 100" aria-hidden="true">
+            <path d="M26 50c0-13 11-24 24-24h24v20c0 13-11 24-24 24h-9l-12 10 3-14c-4-4-6-10-6-16z" fill="none" stroke="#73f0d1" stroke-width="7" stroke-linejoin="round" />
+          </svg>
+          <h3>VeloraChat</h3>
+          <p>Private moments, elegant flow.</p>
+        </div>
+        <div class="chat">
+          <div class="msg other">You online? I sent the roadmap draft.</div>
+          <div class="msg self">Yes — reviewing now. Love the new emblem.</div>
+          <div class="msg other">Perfect. We can ship this to TestFlight tonight.</div>
+        </div>
+      </article>
+    </section>
+
+    <section class="panel">
+      <h2>iPhone App Store Preparation</h2>
+      <p class="muted">This starter screen is designed for your app identity and submission planning.</p>
+      <ul class="appstore-list">
+        <li><strong>Brand Name:</strong> VeloraChat (unique, memorable, message-focused).</li>
+        <li><strong>Visual Style:</strong> Lunar Glass (dark gradient + neon aqua highlights).</li>
+        <li><strong>Emblem:</strong> Triple-dot speech mark with orbit ring for app icon/splash.</li>
+        <li><strong>Meta Tags:</strong> Apple web-app and theme tags included for iOS preview.</li>
+        <li><strong>Next Build Steps:</strong> Add auth, push notifications, message encryption, and App Privacy labels.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/pack/velorachat-owner-pack/README.txt
+++ b/pack/velorachat-owner-pack/README.txt
@@ -1,0 +1,14 @@
+VeloraChat Owner Pack
+=====================
+
+This folder is a ready-to-share business/app handoff pack.
+
+Contents:
+- brand/BRAND_KIT.md
+- app-store/APP_STORE_SUBMISSION_CHECKLIST.md
+- app-store/APP_STORE_LISTING_TEMPLATE.md
+- product/PRODUCT_ONE_PAGER.md
+- operations/LAUNCH_PLAN_30_DAYS.md
+
+To rebuild from source docs, run:
+  bash deploy/build_owner_pack.sh

--- a/pack/velorachat-owner-pack/app-store/APP_STORE_LISTING_TEMPLATE.md
+++ b/pack/velorachat-owner-pack/app-store/APP_STORE_LISTING_TEMPLATE.md
@@ -1,0 +1,31 @@
+# App Store Listing Template
+
+## App Name
+VeloraChat
+
+## Subtitle
+Private messaging with elegant flow
+
+## Promotional Text
+VeloraChat helps you stay connected with calm, private, and beautifully designed conversations.
+
+## Description
+VeloraChat is a messaging app concept focused on clarity, privacy, and a premium iPhone experience.
+
+### Key Features
+- Clean chat experience
+- Push notifications (planned)
+- Sign in with Apple (planned)
+- Privacy-forward product direction
+
+## Keywords
+messaging, chat, private, secure, communication
+
+## Support URL
+https://example.com/support
+
+## Marketing URL
+https://example.com
+
+## Privacy Policy URL
+https://example.com/privacy

--- a/pack/velorachat-owner-pack/app-store/APP_STORE_SUBMISSION_CHECKLIST.md
+++ b/pack/velorachat-owner-pack/app-store/APP_STORE_SUBMISSION_CHECKLIST.md
@@ -1,0 +1,33 @@
+# App Store Submission Checklist (iPhone)
+
+Use this checklist before submitting VeloraChat to Apple.
+
+## 1) App information
+- [ ] Final app name confirmed: **VeloraChat**
+- [ ] Subtitle finalized
+- [ ] Category selected (e.g., Social Networking)
+- [ ] Age rating questionnaire completed
+
+## 2) Legal and policy
+- [ ] Privacy Policy URL ready
+- [ ] Terms of Use URL ready
+- [ ] Data collection details mapped for App Privacy labels
+- [ ] Encryption/export compliance reviewed
+
+## 3) Assets and metadata
+- [ ] App icon exported in required sizes
+- [ ] iPhone screenshots captured for required screen sizes
+- [ ] Promotional text and description finalized
+- [ ] Keywords and support URL completed
+
+## 4) Technical readiness
+- [ ] Production API environment configured
+- [ ] Sign in with Apple tested (if account system exists)
+- [ ] Push notifications (APNs) validated
+- [ ] Crash and analytics monitoring enabled
+
+## 5) Review readiness
+- [ ] Test account credentials prepared for reviewer
+- [ ] Demo steps documented for app review team
+- [ ] Content moderation/reporting flow available
+- [ ] Build uploaded and processed in App Store Connect

--- a/pack/velorachat-owner-pack/brand/BRAND_KIT.md
+++ b/pack/velorachat-owner-pack/brand/BRAND_KIT.md
@@ -1,0 +1,30 @@
+# VeloraChat Brand Kit
+
+## Core identity
+- **Brand name:** VeloraChat
+- **Style name:** Lunar Glass
+- **Brand promise:** A premium private messaging experience with calm visual flow.
+
+## Voice and tone
+- Warm, modern, and reassuring.
+- Clear wording over technical jargon.
+- Privacy-forward language in user-facing copy.
+
+## Color system
+- Background: `#0b1020`
+- Surface card: `#141a30`
+- Accent aqua: `#73f0d1`
+- Accent indigo: `#5a7dff`
+- Primary text: `#eff3ff`
+- Secondary text: `#9ba8c7`
+
+## Emblem guidance
+- Primary shape: rounded chat bubble.
+- Signature detail: three message dots.
+- Optional ring/glow: gradient orbit for premium feel.
+- Must be readable at small icon sizes.
+
+## Tagline options
+1. Private moments, elegant flow.
+2. Message clearly. Connect calmly.
+3. Your conversations, beautifully secure.

--- a/pack/velorachat-owner-pack/operations/LAUNCH_PLAN_30_DAYS.md
+++ b/pack/velorachat-owner-pack/operations/LAUNCH_PLAN_30_DAYS.md
@@ -1,0 +1,21 @@
+# 30-Day Launch Plan
+
+## Week 1
+- Finalize app icon and screenshots
+- Finalize App Store listing copy
+- Configure production backend and logging
+
+## Week 2
+- Complete TestFlight build
+- Internal QA and bug fixes
+- Validate onboarding and push notifications
+
+## Week 3
+- Prepare App Store Connect metadata
+- Complete policy/legal URLs
+- Submit for review
+
+## Week 4
+- Monitor review feedback
+- Plan post-launch update
+- Start small marketing campaign

--- a/pack/velorachat-owner-pack/product-preview.html
+++ b/pack/velorachat-owner-pack/product-preview.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="theme-color" content="#10131f" />
+  <title>VeloraChat — Private Messaging</title>
+  <style>
+    :root {
+      --bg: #0b1020;
+      --card: #141a30;
+      --muted: #9ba8c7;
+      --text: #eff3ff;
+      --brand: #73f0d1;
+      --brand-2: #5a7dff;
+      --bubble-self: #273a7a;
+      --bubble-other: #1d294d;
+      --border: rgba(255, 255, 255, 0.12);
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto, sans-serif;
+      background: radial-gradient(circle at top right, #152047 0%, var(--bg) 55%);
+      color: var(--text);
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: 24px;
+    }
+
+    .app-shell {
+      width: min(980px, 100%);
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 24px;
+    }
+
+    .panel {
+      background: linear-gradient(160deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0));
+      border: 1px solid var(--border);
+      border-radius: 24px;
+      padding: 22px;
+      backdrop-filter: blur(8px);
+      box-shadow: 0 10px 40px rgba(0, 0, 0, 0.35);
+    }
+
+    h1, h2, h3, p {
+      margin-top: 0;
+    }
+
+    .brand-row {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      margin-bottom: 18px;
+    }
+
+    .brand-chip {
+      font-size: 12px;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--brand);
+      border: 1px solid rgba(115, 240, 209, 0.35);
+      border-radius: 999px;
+      padding: 6px 10px;
+    }
+
+    .muted {
+      color: var(--muted);
+      line-height: 1.55;
+    }
+
+    .phone {
+      width: 290px;
+      max-width: 100%;
+      margin: 20px auto 0;
+      border-radius: 36px;
+      border: 10px solid #0a0d16;
+      background: #111833;
+      overflow: hidden;
+      box-shadow: 0 18px 60px rgba(0, 0, 0, 0.5);
+    }
+
+    .phone-notch {
+      width: 42%;
+      height: 24px;
+      border-radius: 0 0 14px 14px;
+      background: #0a0d16;
+      margin: 0 auto;
+    }
+
+    .splash {
+      min-height: 210px;
+      display: grid;
+      place-items: center;
+      background: linear-gradient(160deg, #1e2960 0%, #18224f 45%, #0f1430 100%);
+      padding: 18px;
+      text-align: center;
+    }
+
+    .splash h3 {
+      margin: 12px 0 4px;
+      font-size: 22px;
+    }
+
+    .splash p {
+      margin: 0;
+      color: #b9c8ee;
+      font-size: 13px;
+    }
+
+    .chat {
+      padding: 14px;
+      border-top: 1px solid var(--border);
+      display: grid;
+      gap: 10px;
+      background: #101736;
+    }
+
+    .msg {
+      max-width: 78%;
+      padding: 10px 12px;
+      border-radius: 14px;
+      font-size: 14px;
+      line-height: 1.35;
+    }
+
+    .other { background: var(--bubble-other); }
+    .self {
+      background: var(--bubble-self);
+      margin-left: auto;
+    }
+
+    .appstore-list {
+      padding-left: 18px;
+      line-height: 1.7;
+      color: #d4dcf5;
+    }
+
+    .appstore-list li::marker { color: var(--brand); }
+
+    @media (max-width: 860px) {
+      .app-shell { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <main class="app-shell">
+    <section class="panel">
+      <div class="brand-row">
+        <svg width="56" height="56" viewBox="0 0 100 100" role="img" aria-label="VeloraChat emblem">
+          <defs>
+            <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stop-color="#73f0d1" />
+              <stop offset="100%" stop-color="#5a7dff" />
+            </linearGradient>
+          </defs>
+          <circle cx="50" cy="50" r="42" fill="url(#g)" opacity="0.18" />
+          <path d="M26 50c0-13 11-24 24-24h24v20c0 13-11 24-24 24h-9l-12 10 3-14c-4-4-6-10-6-16z" fill="none" stroke="url(#g)" stroke-width="6" stroke-linejoin="round" />
+          <circle cx="46" cy="50" r="3" fill="#73f0d1" />
+          <circle cx="58" cy="50" r="3" fill="#73f0d1" />
+          <circle cx="70" cy="50" r="3" fill="#73f0d1" />
+        </svg>
+        <div>
+          <h1>VeloraChat</h1>
+          <div class="brand-chip">Signature Style: Lunar Glass</div>
+        </div>
+      </div>
+      <p class="muted">
+        A uniquely branded messaging app concept with an iPhone-first visual language.
+        Emblem + name are ready for splash screens, App Store marketing art, and icon exploration.
+      </p>
+
+      <article class="phone" aria-label="iPhone preview">
+        <div class="phone-notch"></div>
+        <div class="splash">
+          <svg width="62" height="62" viewBox="0 0 100 100" aria-hidden="true">
+            <path d="M26 50c0-13 11-24 24-24h24v20c0 13-11 24-24 24h-9l-12 10 3-14c-4-4-6-10-6-16z" fill="none" stroke="#73f0d1" stroke-width="7" stroke-linejoin="round" />
+          </svg>
+          <h3>VeloraChat</h3>
+          <p>Private moments, elegant flow.</p>
+        </div>
+        <div class="chat">
+          <div class="msg other">You online? I sent the roadmap draft.</div>
+          <div class="msg self">Yes — reviewing now. Love the new emblem.</div>
+          <div class="msg other">Perfect. We can ship this to TestFlight tonight.</div>
+        </div>
+      </article>
+    </section>
+
+    <section class="panel">
+      <h2>iPhone App Store Preparation</h2>
+      <p class="muted">This starter screen is designed for your app identity and submission planning.</p>
+      <ul class="appstore-list">
+        <li><strong>Brand Name:</strong> VeloraChat (unique, memorable, message-focused).</li>
+        <li><strong>Visual Style:</strong> Lunar Glass (dark gradient + neon aqua highlights).</li>
+        <li><strong>Emblem:</strong> Triple-dot speech mark with orbit ring for app icon/splash.</li>
+        <li><strong>Meta Tags:</strong> Apple web-app and theme tags included for iOS preview.</li>
+        <li><strong>Next Build Steps:</strong> Add auth, push notifications, message encryption, and App Privacy labels.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/pack/velorachat-owner-pack/product/PRODUCT_ONE_PAGER.md
+++ b/pack/velorachat-owner-pack/product/PRODUCT_ONE_PAGER.md
@@ -1,0 +1,23 @@
+# VeloraChat Product One-Pager
+
+## Vision
+Create a premium, privacy-forward messaging app for iPhone users.
+
+## Target users
+- Individuals who want clear and focused communication
+- Small teams/families that value simple chat UX
+
+## Value proposition
+VeloraChat combines elegant interface design with practical messaging essentials.
+
+## MVP scope
+- Account onboarding
+- 1:1 messaging
+- Conversation list
+- Push notifications
+- Basic profile settings
+
+## Monetization options
+- Free tier + premium themes
+- Subscription for advanced features
+- Team plan for shared spaces

--- a/qna_plugin/whisper_bot.js
+++ b/qna_plugin/whisper_bot.js
@@ -1,0 +1,5 @@
+
+// Simple Q&A Whisper Bot plugin
+function askIVP(question) {
+  return "Answering: " + question + " (powered by IVP WhisperBot)";
+}


### PR DESCRIPTION
### Motivation
- Provide a small product starter for VeloraChat including an iPhone-style preview, brand assets, and App Store-ready copy to support design and submission work. 
- Add simple deployment/helpers to generate distributable owner and business ZIP packages for handoff. 
- Include a minimal backend stub and a tiny Q&A plugin scaffold so developers have a runnable starting point.

### Description
- Added a branded frontend preview at `frontend/index.html` and a packaged preview in `pack/velorachat-owner-pack/product-preview.html` to showcase the app look and App Store guidance. 
- Added documentation and business artifacts including `docs/README.md`, `docs/BUSINESS_PACK.md`, `docs/BRAND_KIT.md`, and `docs/APP_STORE_SUBMISSION_CHECKLIST.md` plus owner-pack content under `pack/velorachat-owner-pack/`. 
- Added deployment and packaging scripts `deploy/package_business_files.sh`, `deploy/build_owner_pack.sh`, and `deploy/deploy.sh` that create ZIP outputs in `dist/` (e.g. `dist/velorachat-business-pack.zip` and `dist/velorachat-owner-pack.zip`). 
- Added a minimal Flask backend stub `backend/app.py`, a simple plugin scaffold `qna_plugin/whisper_bot.js`, and a `.gitignore` to filter common Python artifacts.

### Testing
- No automated test suite was configured or run as part of this change. 
- Packaging scripts can be exercised with `bash deploy/package_business_files.sh` and `bash deploy/build_owner_pack.sh` to produce ZIP outputs in `dist/` (these were not run in CI). 
- Manual inspection of the new HTML and docs was performed to verify content rendering (no automated checks).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a96294dcd48325aa69b0f2ce23b40f)